### PR TITLE
Prevent error "Call to undefined function Deployer\local()"

### DIFF
--- a/config/local.php.dist
+++ b/config/local.php.dist
@@ -10,7 +10,7 @@ namespace Deployer;
 
 use N98\Deployer\RoleManager;
 
-$local = local('local');
+$local = localhost('local');
 $local->user('__ADD_YOUR_LOCAL_USERNAME__');
 $local->set('deploy_path', '__ADD_DEPLOY_PATH__');
 $local->stage('dev');


### PR DESCRIPTION
When following the readme an error "Call to undefined function Deployer\local()" occured while using the "local" deployment based on the file `config/local.php.dist`.

When changing the function call to `$local = localhost('local');` everything works as expected.